### PR TITLE
Python 3 and Django >= 1.8 support

### DIFF
--- a/raiseexception/tests.py
+++ b/raiseexception/tests.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # (c) 2012 Bright Interactive Limited. All rights reserved.
 # http://www.bright-interactive.com | info@bright-interactive.com
+from __future__ import absolute_import
 
 from django.test import TestCase
 from django.core.urlresolvers import reverse
-from views import raise_exception
+from .views import raise_exception
 from raiseexception import DeliberateException
 
 

--- a/raiseexception/urls.py
+++ b/raiseexception/urls.py
@@ -1,10 +1,17 @@
 # -*- coding: utf-8 -*-
 # (c) 2012 Bright Interactive Limited. All rights reserved.
 # http://www.bright-interactive.com | info@bright-interactive.com
+from __future__ import absolute_import
 
-from django.conf.urls.defaults import patterns, url
+from .views import raise_exception
+
+try:
+    from django.conf.urls.defaults import patterns, url
+    urlpatterns = patterns('raiseexception.views', url(r'^raise-exception$', 'raise_exception', name='raise-exception'),)
+
+except ImportError:
+    # django > 1.8
+    from django.conf.urls import url
+    urlpatterns = [url(r'^raise-exception$', raise_exception, name='raise-exception'),]
 
 
-urlpatterns = patterns('raiseexception.views',
-    url(r'^raise-exception$', 'raise_exception', name='raise-exception'),
-)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 from setuptools import setup
 import re
@@ -53,9 +54,9 @@ def get_package_data(package):
 if sys.argv[-1] == 'publish':
     os.system("python setup.py sdist upload")
     args = {'version': get_version(package)}
-    print "You probably want to also tag the version now:"
-    print "  git tag -a %(version)s -m 'version %(version)s'" % args
-    print "  git push --tags"
+    print("You probably want to also tag the version now:")
+    print("  git tag -a %(version)s -m 'version %(version)s'" % args)
+    print("  git push --tags")
     sys.exit()
 
 

--- a/testsettings.py
+++ b/testsettings.py
@@ -10,3 +10,5 @@ INSTALLED_APPS = (
 )
 
 ROOT_URLCONF = 'raiseexception.urls'
+
+SECRET_KEY = 'YS+ATOQdtOwhA4TRgIyOBO12y7bGswjW9W0NTFjED8bYAqF/RA'

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist=
     py27-django13,
     py26-django14,
     py27-django14,
+    py3-django18,
+    py3-django111,
 
 [testenv]
 commands=
@@ -30,3 +32,13 @@ deps=
 basepython=python2.7
 deps=
     django==1.4
+
+[testenv:py3-django18]
+basepython=python3
+deps=
+    django==1.8
+
+[testenv:py3-django111]
+basepython=python3
+deps=
+    django==1.11


### PR DESCRIPTION
- url patterns are constructed differently in django versions greater than 1.8
- use python 3 print function
- add python 3 and django 1.8, django 1.11 tests to tox